### PR TITLE
Fix: Add use of HashRouter to address 404 refreshes.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import './App.css';
 import Navbar from './components/Navbar';
-import { BrowserRouter as Router, Routes, Route} from 'react-router-dom'
+/* Need to use HashRouter since BrowserRouter doesn't play nicely with gh pages*/
+import { HashRouter as Router, Routes, Route} from 'react-router-dom'
 import Home from './components/pages/Home/Home'
 import About from './components/pages/About/About'
 import Articles from './components/pages/Article/Articles'
@@ -12,7 +13,7 @@ import Credits from './components/pages/Credits/Credits'
 function App() {
   return (
     <>
-      <Router>
+      <Router basename="/">
         <Navbar />
         <Routes>
           <Route path='/' exact element={<Home />} />


### PR DESCRIPTION
## Proposed Changes

After traversing the blog and trying to refresh on one of the pages (such as Articles), we get a 404 from GitHub mentioning that it can't find the file indicated. After some research, the cause of this is due to the use of `BrowserRouter` as there exist some issues with compatibility when using it with GitHub Pages.


## Expected Output
With these changes, whenever you try to refresh on another page that isn't the home one (such as Articles), it should not present you with a 404 message anymore.

## Testing
I tested this live by deploying locally and GH pages. I was able to verify that the following changes do not result in a 404 page anymore after refresh.

## References
- https://stackoverflow.com/questions/68025460/react-app-deployment-on-github-pages-shows-a-blank-page
- https://medium.com/@bennirus/deploying-a-create-react-app-with-routing-to-github-pages-f386b6ce84c2